### PR TITLE
Fix links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ your own platforms.
 To get up and running with Nucleus implementations, check out the [implementations]
 directory. The [duktape `README`] is a great place to start.
 
-[implementations]: tree/master/implementations
-[duktape `README`]: blob/master/implementations/duktape/README.md
+[implementations]: implementations
+[duktape `README`]: implementations/duktape/README.md
 
 ## Command Line Interface
 


### PR DESCRIPTION
GitHub adds this stuff for relative links already.
