### PR TITLE
Docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ directory. The [duktape `README`] is a great place to start.
 [implementations]: implementations
 [duktape `README`]: implementations/duktape/README.md
 
+## Running the tests
+
+The test suite can be found in `test`, and can be run with
+`make test-<implementation>`, e.g. `make test-duktape`.
+
 ## Command Line Interface
 
 ```sh

--- a/implementations/duktape/Makefile
+++ b/implementations/duktape/Makefile
@@ -17,7 +17,10 @@ rust_path/target/release/libc_path.a: rust_path/src/lib.rs rust_path/src/helpers
 install: nucleus
 	install nucleus /usr/local/bin/
 
-test: test-dir test-zip test-app test-app-tiny
+test:
+	make -C ../.. test-duktape
+
+test-manual: test-dir test-zip test-app test-app-tiny
 
 test-dir: nucleus
 	./nucleus ../../test/manual -- 1 2 3

--- a/implementations/duktape/README.md
+++ b/implementations/duktape/README.md
@@ -28,6 +28,13 @@ make test
 When you're done building the `nucleus` binary can be used to run and build your
 own tiny JS scripts.
 
+## Testing
+
+Run `make -j4 test`. It will also attempt (re)build if you have not already.
+
+Additionally, there are some manually verified tests. To run these, use
+`make test-manual`.
+
 ## Optimizing for Size
 
 By default the Makefile builds in debug mode with `-g`.  If you want a tiny


### PR DESCRIPTION
"Fixed" running the test runner from the duktape impl. 
(I'll try to figure out with some more pythony-node-people why it doesn't currently work from a directory below the top-level.)

Added some docs about running the tests.
